### PR TITLE
オプションの追加：matchWholeWord

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ You can set highlight colors.
 | Setting                                     | Description                                                            | Type    | Default Value            |
 | ------------------------------------------- | ---------------------------------------------------------------------- | ------- | ------------------------ |
 | multiwindows-highlight.caseInsensitive      | Case insensitive highlight option.                                     | boolean | False                    |
+| multiwindows-highlight.matchWholeWord       | Match whole word highlight option.                                     | boolean | False                    |
 | multiwindows-highlight.darkBackgroundColor  | highlight background color for dark thema. ex: rgba(255, 0, 155, 0.5)  | string  | rgba(255, 255, 204, 0.3) |
 | multiwindows-highlight.darkBorderColor      | highlight border color for dark thema. ex: rgba(255, 0, 155, 0.5)      | string  | rgba(255, 255, 204, 0.4) |
 | multiwindows-highlight.darkColor            | highlight font color for dark thema. ex: rgba(255, 0, 155, 0.5)        | string  | rgba(255, 255, 0, 1.0)   |

--- a/extension.js
+++ b/extension.js
@@ -2,7 +2,6 @@
 // Import the module and reference it with the alias vscode in your code below
 const vscode = require('vscode');
 var curDecorator;
-let userConf;
 var onDidChangeVisibleTextEditorsFlg = false;
 
 // this method is called when your extension is activated
@@ -12,11 +11,7 @@ var onDidChangeVisibleTextEditorsFlg = false;
  * @param {vscode.ExtensionContext} context
  */
 function activate(context) {
-	// ユーザ設定読み込み
-	userConf = vscode.workspace.getConfiguration('multiwindows-highlight');
-
 	decorateSameWords();
-	exports.activate = activate;
 	const disposable1 = vscode.window.onDidChangeVisibleTextEditors(event => {
 		onDidChangeVisibleTextEditorsFlg = true;
 		deleteDecorator(curDecorator);
@@ -41,8 +36,10 @@ function deleteDecorator(deleteDecorator) {
 	}
 }
 function decorateSameWords(curSelection) {
+	// ユーザ設定読み込み、
+	const userConf = vscode.workspace.getConfiguration('multiwindows-highlight');
 	const editor = vscode.window.activeTextEditor;
-	if ((!editor) || (onDidChangeVisibleTextEditorsFlg == true)) {
+	if ((!editor) || (!curSelection) || (onDidChangeVisibleTextEditorsFlg == true)) {
 		onDidChangeVisibleTextEditorsFlg = false;
 		return;
 	}

--- a/package.json
+++ b/package.json
@@ -69,6 +69,11 @@
 						"type": "boolean",
 						"default": false,
 						"description": "Case insensitive highlight option."
+					},
+					"multiwindows-highlight.matchWholeWord": {
+						"type": "boolean",
+						"default": false,
+						"description": "Match whole word highlight option."
 					}
 				}
 			}


### PR DESCRIPTION
もともとの設定では、以下の文字の `state` 部分がハイライトされる

- **state**
- search_**state**

`matchWholeWord` の値は `true` にすれば、`state` のみハイライトされる。

- **state**
- search_state

とても役に立つ機能で、追加していただけると嬉しいです！